### PR TITLE
Disable colorization in sync with Pytest

### DIFF
--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -1,9 +1,6 @@
 from pprintpp import pformat
 import icdiff
-import py
 
-COLOR_OFF = icdiff.color_codes['none']
-COLS = py.io.TerminalWriter().fullwidth - 12
 
 def pytest_assertrepr_compare(config, op, left, right):
     if op != '==':
@@ -15,9 +12,11 @@ def pytest_assertrepr_compare(config, op, left, right):
     except TypeError:
         pass
 
+    terminal_writer = config.get_terminal_writer()
+    cols = terminal_writer.fullwidth - 12
 
-    wide_left = pformat(left, indent=2, width=COLS / 2).splitlines()
-    wide_right = pformat(right, indent=2, width=COLS / 2).splitlines()
+    wide_left = pformat(left, indent=2, width=cols / 2).splitlines()
+    wide_right = pformat(right, indent=2, width=cols / 2).splitlines()
     if len(wide_left) < 3 or len(wide_right) < 3:
         shortest_left = pformat(left, indent=2, width=1).splitlines()
         shortest_right = pformat(right, indent=2, width=1).splitlines()
@@ -29,8 +28,18 @@ def pytest_assertrepr_compare(config, op, left, right):
     pretty_right = pformat(right, indent=2, width=cols / 2).splitlines()
 
 
-    icdiff_lines = list(icdiff.ConsoleDiff(cols=cols + 12, tabsize=2).make_table(
-        pretty_left, pretty_right
-    ))
+    differ = icdiff.ConsoleDiff(cols=cols + 12, tabsize=2)
 
-    return ['equals failed'] + [f'{COLOR_OFF}{l}' for l in icdiff_lines]
+    if not terminal_writer.hasmarkup:
+        # colorization is disabled in Pytest - either due to the terminal not
+        # supporting it or the user disabling it. We should obey, but there is
+        # no option in icdiff to disable it, so we replace its colorization
+        # function with a no-op
+        differ.colorize = lambda string: string
+        color_off = ''
+    else:
+        color_off = icdiff.color_codes['none']
+
+    icdiff_lines = list(differ.make_table(pretty_left, pretty_right))
+
+    return ['equals failed'] + [color_off + l for l in icdiff_lines]

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -26,6 +26,34 @@ def test_short_dict(testdir):
     )
     output = testdir.runpytest().stdout.str()
     print(repr(output))
+    two_left = "'the number two'"
+    two_right = "'the number three'"
+    assert two_left in output
+    assert two_right in output
+    three_diff = "  6: [1, 2, 3],"
+    assert three_diff in output
+
+
+def test_short_dict_with_colorization(testdir):
+    one = {
+        1: "the number one",
+        2: "the number two",
+    }
+    two = {
+        1: "the number one",
+        2: "the number three",
+        6: [1, 2, 3]
+    }
+    testdir.makepyfile(
+        f"""
+        def test_one():
+            assert {one!r} == {two!r}
+        """
+    )
+    # Force colorization in py TerminalWriter
+    testdir._env_run_update['PY_COLORS'] = '1'
+    output = testdir.runpytest().stdout.str()
+    print(repr(output))
     two_left = f"'the number t{YELLOW_ON}wo{COLOR_OFF}'"
     two_right = f"'the number t{YELLOW_ON}hree{COLOR_OFF}'"
     assert two_left in output


### PR DESCRIPTION
Fixes #9.

Pytest has a number of mechanisms for enabling or disabling colorization including environment variables and detection whether the output terminal supports it. This plugin should follow suite with it.