### PR TITLE
Correct license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='obeythetestinggoat@gmail.com',
     maintainer='Harry Percival',
     maintainer_email='obeythetestinggoat@gmail.com',
-    license='GNU GPL v3.0',
+    license='Unlicense',
     url='https://github.com/hjwp/pytest-icdiff',
     description='use icdiff for better error messages in pytest assertions',
     long_description=read('README.rst'),


### PR DESCRIPTION
The README and License files say it's released under the Unlicense, so synchronize with that. The `license` field from `setup()` is what tends to get read by automated license checkers, without this the library would be flagged as GPL which is not usable by many folks.