### PR TITLE
handle edge case of short diffs containing long elements better

### DIFF
--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -1,6 +1,13 @@
 # pylint: disable=inconsistent-return-statements
+import py
 from pprintpp import pformat
 import icdiff
+
+COLS = py.io.TerminalWriter().fullwidth  # pylint: disable=no-member
+MARGIN_L = 9
+GUTTER = 2
+MARGINS = MARGIN_L + GUTTER + 1
+
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -13,26 +20,23 @@ def pytest_assertrepr_compare(config, op, left, right):
     except TypeError:
         pass
 
-    terminal_writer = config.get_terminal_writer()
-    cols = terminal_writer.fullwidth - 12
+    half_cols = COLS / 2 - MARGINS
 
-    wide_left = pformat(left, indent=2, width=cols / 2).splitlines()
-    wide_right = pformat(right, indent=2, width=cols / 2).splitlines()
-    if len(wide_left) < 3 or len(wide_right) < 3:
-        shortest_left = pformat(left, indent=2, width=1).splitlines()
-        shortest_right = pformat(right, indent=2, width=1).splitlines()
-        longest_line_length = max(len(l) for l in shortest_left + shortest_right)
-    else:
-        longest_line_length = max(len(l) for l in wide_left + wide_right)
-    cols = int(min(longest_line_length, cols))
+    pretty_left = pformat(left, indent=2, width=half_cols).splitlines()
+    pretty_right = pformat(right, indent=2, width=half_cols).splitlines()
+    diff_cols = COLS - MARGINS
 
-    pretty_left = pformat(left, indent=2, width=cols / 2).splitlines()
-    pretty_right = pformat(right, indent=2, width=cols / 2).splitlines()
+    if len(pretty_left) < 3 or len(pretty_right) < 3:
+        # avoid small diffs far apart by smooshing them up to the left
+        pretty_left = pformat(left, indent=2, width=1).splitlines()
+        pretty_right = pformat(right, indent=2, width=1).splitlines()
+        diff_cols = max(len(l) + 1 for l in pretty_left + pretty_right) * 2
+        if (diff_cols + MARGINS) > COLS:
+            diff_cols = COLS - MARGINS
 
+    differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
 
-    differ = icdiff.ConsoleDiff(cols=cols + 12, tabsize=2)
-
-    if not terminal_writer.hasmarkup:
+    if not config.get_terminal_writer().hasmarkup:
         # colorization is disabled in Pytest - either due to the terminal not
         # supporting it or the user disabling it. We should obey, but there is
         # no option in icdiff to disable it, so we replace its colorization
@@ -44,4 +48,4 @@ def pytest_assertrepr_compare(config, op, left, right):
 
     icdiff_lines = list(differ.make_table(pretty_left, pretty_right))
 
-    return ['equals failed'] + [color_off + l for l in icdiff_lines]
+    return [f'equals failed'] + [color_off + l for l in icdiff_lines]

--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -21,10 +21,10 @@ def pytest_assertrepr_compare(config, op, left, right):
     if len(wide_left) < 3 or len(wide_right) < 3:
         shortest_left = pformat(left, indent=2, width=1).splitlines()
         shortest_right = pformat(right, indent=2, width=1).splitlines()
-        cols = max(len(l) for l in shortest_left + shortest_right) * 2
+        longest_line_length = max(len(l) for l in shortest_left + shortest_right)
     else:
         longest_line_length = max(len(l) for l in wide_left + wide_right)
-        cols = int(min(longest_line_length, cols / 2))
+    cols = int(min(longest_line_length, cols))
 
     pretty_left = pformat(left, indent=2, width=cols / 2).splitlines()
     pretty_right = pformat(right, indent=2, width=cols / 2).splitlines()

--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -9,7 +9,6 @@ GUTTER = 2
 MARGINS = MARGIN_L + GUTTER + 1
 
 
-
 def pytest_assertrepr_compare(config, op, left, right):
     if op != '==':
         return
@@ -48,4 +47,4 @@ def pytest_assertrepr_compare(config, op, left, right):
 
     icdiff_lines = list(differ.make_table(pretty_left, pretty_right))
 
-    return [f'equals failed'] + [color_off + l for l in icdiff_lines]
+    return ['equals failed'] + [color_off + l for l in icdiff_lines]

--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -1,3 +1,4 @@
+# pylint: disable=inconsistent-return-statements
 from pprintpp import pformat
 import icdiff
 
@@ -22,7 +23,8 @@ def pytest_assertrepr_compare(config, op, left, right):
         shortest_right = pformat(right, indent=2, width=1).splitlines()
         cols = max(len(l) for l in shortest_left + shortest_right) * 2
     else:
-        cols = max(len(l) for l in wide_left + wide_right) * 2
+        longest_line_length = max(len(l) for l in wide_left + wide_right)
+        cols = int(min(longest_line_length, cols / 2))
 
     pretty_left = pformat(left, indent=2, width=cols / 2).splitlines()
     pretty_right = pformat(right, indent=2, width=cols / 2).splitlines()

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -191,8 +191,8 @@ def test_does_not_break_drilldown_for_int_comparison(testdir):
 
 
 def test_long_lines_in_comparators_are_wrapped_sensibly_multiline(testdir):
-    left = {1: "hello " * 20}
-    right = {1: "hella " * 20}
+    left = {1: "hello " * 20, 2: 'two'}
+    right = {1: "hella " * 20, 2: 'two'}
     testdir.makepyfile(
         f"""
         def test_one():

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -190,7 +190,7 @@ def test_does_not_break_drilldown_for_int_comparison(testdir):
     assert drilldown_expression in output
 
 
-def test_long_lines_in_comparators_are_wrapped_sensibly(testdir):
+def test_long_lines_in_comparators_are_wrapped_sensibly_multiline(testdir):
     left = {1: "hello " * 20}
     right = {1: "hella " * 20}
     testdir.makepyfile(
@@ -201,4 +201,21 @@ def test_long_lines_in_comparators_are_wrapped_sensibly(testdir):
     )
     output = testdir.runpytest('-vv', '--color=yes').stdout.str()
     comparison_line = next(l for l in output.splitlines() if '1:' in l and "assert" not in l)
-    assert len(comparison_line) < 120
+    assert comparison_line.count('hell') < 13
+
+def test_long_lines_in_comparators_are_wrapped_sensibly_singleline(testdir):
+    left = "hello " * 10
+    right = "hella " * 10
+    testdir.makepyfile(
+        f"""
+        def test_one():
+            assert {left!r} == {right!r}
+        """
+    )
+    output = testdir.runpytest('-vv', '--color=yes').stdout.str()
+    comparison_line = next(
+        l for l in output.splitlines()
+        if "hell" in l
+        and "assert" not in l
+    )
+    assert comparison_line.count('hell') < 13

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -188,3 +188,17 @@ def test_does_not_break_drilldown_for_int_comparison(testdir):
     output = testdir.runpytest().stdout.str()
     drilldown_expression = 'where 3 = len([1, 2, 3])'
     assert drilldown_expression in output
+
+
+def test_long_lines_in_comparators_are_wrapped_sensibly(testdir):
+    left = {1: "hello " * 20}
+    right = {1: "hella " * 20}
+    testdir.makepyfile(
+        f"""
+        def test_one():
+            assert {left!r} == {right!r}
+        """
+    )
+    output = testdir.runpytest('-vv', '--color=yes').stdout.str()
+    comparison_line = next(l for l in output.splitlines() if '1:' in l and "assert" not in l)
+    assert len(comparison_line) < 120

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -52,7 +52,7 @@ def test_short_dict_with_colorization(testdir):
     )
     # Force colorization in py TerminalWriter
     testdir.monkeypatch.setenv('PY_COLORS', '1')
-    output = testdir.runpytest().stdout.str()
+    output = testdir.runpytest('-vv').stdout.str()
     print(repr(output))
     two_left = f"'the number t{YELLOW_ON}wo{COLOR_OFF}'"
     two_right = f"'the number t{YELLOW_ON}hree{COLOR_OFF}'"
@@ -215,8 +215,7 @@ def test_long_lines_in_comparators_are_wrapped_sensibly_singleline(testdir):
     output = testdir.runpytest('-vv', '--color=yes').stdout.str()
     comparison_line = next(
         l for l in output.splitlines()
-        if "hell" in l
-        and "assert" not in l
+        if "hell" in l and "assert" not in l
     )
     assert comparison_line.count('hell') < 15
 


### PR DESCRIPTION
also fixes the way we detect current terminal width, which was broken. for me at least.  comments welcomed.