### PR TITLE
Use shutil.get_terminal_size

### DIFF
--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -1,9 +1,9 @@
 # pylint: disable=inconsistent-return-statements
-import os
+import shutil
 from pprintpp import pformat
 import icdiff
 
-COLS = os.get_terminal_size().columns
+COLS = shutil.get_terminal_size().columns
 MARGIN_L = 10
 GUTTER = 2
 MARGINS = MARGIN_L + GUTTER + 1


### PR DESCRIPTION
When trying to run the git master of pytest-icdiff on GitHub Actions, [I get](https://github.com/qutebrowser/experiments/runs/2165113905?check_suite_focus=true):

```pytb
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pytest/__main__.py", line 5, in <module>
    raise SystemExit(pytest.console_main())
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 188, in console_main
    code = main()
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 146, in main
    config = _prepareconfig(args, plugins)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 325, in _prepareconfig
    config = pluginmanager.hook.pytest_cmdline_parse(
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/hooks.py", line 281, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/manager.py", line 84, in <lambda>
    self._inner_hookexec = lambda hook, methods, kwargs: _multicall(
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/callers.py", line 130, in _multicall
    gen.send(outcome)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/helpconfig.py", line 100, in pytest_cmdline_parse
    config: Config = outcome.get_result()
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/callers.py", line 114, in _multicall
    res = hook_impl.function(*args)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1022, in pytest_cmdline_parse
    self.parse(args)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1308, in parse
    self._preparse(args, addopts=addopts)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/config/__init__.py", line 1191, in _preparse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pluggy/manager.py", line 300, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/_pytest/assertion/rewrite.py", line 169, in exec_module
    exec(co, module.__dict__)
  File "/__w/experiments/experiments/.tox/bleeding/lib/python3.9/site-packages/pytest_icdiff.py", line 6, in <module>
    COLS = os.get_terminal_size().columns
OSError: [Errno 25] Inappropriate ioctl for device
```

Note that the [Python docs say](https://docs.python.org/3/library/os.html#os.get_terminal_size):

> [shutil.get_terminal_size()](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size) is the high-level function which should normally be used, `os.get_terminal_size` is the low-level implementation.

And indeed the high-level implementation [handles this case](https://github.com/python/cpython/blob/v3.9.2/Lib/shutil.py#L1350-L1353) (and some others, like overriding `COLUMNS` in the environment) correctly.