### PR TITLE
drop Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=read("README.rst") + read("HISTORY.rst"),
     long_description_content_type="text/x-rst",
     py_modules=["pytest_icdiff"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["pytest", "icdiff", "pprintpp"],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -32,7 +32,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py36,py37,py38,py39,py310,flake8
+envlist = py37,py38,py39,py310,flake8
 
 [testenv]
 deps = pytest>=3.0


### PR DESCRIPTION
Python 3.6 is no longer supported, see https://www.python.org/downloads/release/python-3615/.

I suggest to set the minimal version here to 3.7.