### PR TITLE
Add command line options from icdiff

### DIFF
--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -72,19 +72,19 @@ def pytest_assertrepr_compare(config, op, left, right):
     half_cols = COLS / 2 - MARGINS
     TABSIZE = int(config.getoption("--tabsize") or 2)
 
-    pretty_left = pformat(left, indent=2, width=half_cols).splitlines()
-    pretty_right = pformat(right, indent=2, width=half_cols).splitlines()
+    pretty_left = pformat(left, indent=TABSIZE, width=half_cols).splitlines()
+    pretty_right = pformat(right, indent=TABSIZE, width=half_cols).splitlines()
     diff_cols = COLS - MARGINS
 
     if len(pretty_left) < 3 or len(pretty_right) < 3:
         # avoid small diffs far apart by smooshing them up to the left
-        smallest_left = pformat(left, indent=2, width=1).splitlines()
-        smallest_right = pformat(right, indent=2, width=1).splitlines()
+        smallest_left = pformat(left, indent=TABSIZE, width=1).splitlines()
+        smallest_right = pformat(right, indent=TABSIZE, width=1).splitlines()
         max_side = max(len(l) + 1 for l in smallest_left + smallest_right)
         if (max_side * 2 + MARGINS) < COLS:
             diff_cols = max_side * 2 + GUTTER
-            pretty_left = pformat(left, indent=2, width=max_side).splitlines()
-            pretty_right = pformat(right, indent=2, width=max_side).splitlines()
+            pretty_left = pformat(left, indent=TABSIZE, width=max_side).splitlines()
+            pretty_right = pformat(right, indent=TABSIZE, width=max_side).splitlines()
 
     differ = icdiff.ConsoleDiff(
         cols=diff_cols,

--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -3,7 +3,7 @@ import shutil
 from pprintpp import pformat
 import icdiff
 
-COLS = shutil.get_terminal_size().columns
+AUTO_COLS = shutil.get_terminal_size().columns
 MARGIN_L = 10
 GUTTER = 2
 MARGINS = MARGIN_L + GUTTER + 1
@@ -12,6 +12,50 @@ MARGINS = MARGIN_L + GUTTER + 1
 #     with open('/tmp/icdiff-debug.txt', 'a') as f:
 #         f.write(' '.join(str(thing) for thing in things))
 #         f.write('\n')
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--cols",
+        action="store",
+        default=None,
+        help="pytest-icdiff:  specify the width of the screen, in case autodetection fails you",
+    )
+    parser.addoption(
+        "--show-all-spaces",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  color all non-matching whitespace including that which is not needed for drawing the eye to changes.  Slow, ugly, displays all changes",
+    )
+    parser.addoption(
+        "--highlight",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  color by changing the background color instead of the foreground color.  Very fast, ugly, displays all changes",
+    )
+    parser.addoption(
+        "--line-numbers",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  generate output with line numbers. Not compatible with the 'exclude-lines' option.",
+    )
+    parser.addoption(
+        "--tabsize",
+        default=2,
+        help="pytest-icdiff:  tab stop spacing",
+    )
+    parser.addoption(
+        "--truncate",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  truncate long lines instead of wrapping them",
+    )
+    parser.addoption(
+        "--strip-trailing-cr",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  strip any trailing carriage return at the end of an input line",
+    )
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -24,7 +68,9 @@ def pytest_assertrepr_compare(config, op, left, right):
     except TypeError:
         pass
 
+    COLS = int(config.getoption("--cols") or AUTO_COLS)
     half_cols = COLS / 2 - MARGINS
+    TABSIZE = int(config.getoption("--tabsize") or 2)
 
     pretty_left = pformat(left, indent=2, width=half_cols).splitlines()
     pretty_right = pformat(right, indent=2, width=half_cols).splitlines()
@@ -40,7 +86,15 @@ def pytest_assertrepr_compare(config, op, left, right):
             pretty_left = pformat(left, indent=2, width=max_side).splitlines()
             pretty_right = pformat(right, indent=2, width=max_side).splitlines()
 
-    differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
+    differ = icdiff.ConsoleDiff(
+        cols=diff_cols,
+        show_all_spaces=config.getoption("--show-all-spaces"),
+        highlight=config.getoption("--highlight"),
+        line_numbers=config.getoption("--line-numbers"),
+        tabsize=TABSIZE,
+        truncate=config.getoption("--truncate"),
+        strip_trailing_cr=config.getoption("--strip-trailing-cr"),
+    )
 
     if not config.get_terminal_writer().hasmarkup:
         # colorization is disabled in Pytest - either due to the terminal not


### PR DESCRIPTION
As I suggested in #33. This should make available the flexibility icdiff already has a bit more for pytest as well. This is more or less just a quick hack on my part, I did not spend enough time to test whether all options actually work as intended, I merely made sure the current tests pass (which they only do when the terminal has a specific width btw. – e.g. 86, as I figured out. This is even before my contribution).

- `--cols`
- `--show-all-spaces`
- `--highlight`
- `--line-numbers`
- `--tabsize`
- `--truncate`
- `--strip-trailing-cr`

The descriptions for these options are taken [directly from icdiff itself](https://github.com/jeffkaufman/icdiff/blob/master/icdiff#L548).