### PR TITLE
Use absolute link to fix image on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Usage
 
 Once you've installed it, ``pytest`` will produce nice colourised diffs for any ``assert ==`` :
 
-.. image:: example_output.png?raw=true
+.. image:: https://raw.githubusercontent.com/hjwp/pytest-icdiff/master/example_output.png?raw=true
    :alt: example colourised diff
 
 Issues and PRs welcome.


### PR DESCRIPTION
The image is broken on [PyPI](https://pypi.org/project/pytest-icdiff/) because of the relative link:

<img width="629" alt="image" src="https://github.com/hjwp/pytest-icdiff/assets/1324225/442ed808-766c-45f2-8152-877ba330c511">

Using an absolute one should fix it.