### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release Package
+
+on: [workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  build_package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist and wheel
+        run: pipx run build --sdist --wheel
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist
+
+  pypi-publish:
+    needs: [build_package]
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This change adds a new GitHub Action workflow that builds and publishes this packages as both an sdist/wheel.

It's triggered on `workflow_dispatch` (meaning manual triggering) because it wasn't obvious how this package is normally released. [This article](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) describes how to run it.

Fixes https://github.com/hjwp/pytest-icdiff/issues/43