### PR TITLE
Better visualize differences in multiline strings

### DIFF
--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -56,6 +56,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="pytest-icdiff:  strip any trailing carriage return at the end of an input line",
     )
+    parser.addoption(
+        "--icdiff-multiline-string",
+        default=False,
+        action="store_true",
+        help="pytest-icdiff:  proper differences for multiline strings",
+    )
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -76,8 +82,16 @@ def pytest_assertrepr_compare(config, op, left, right):
     half_cols = COLS / 2 - MARGINS
     TABSIZE = int(config.getoption("--icdiff-tabsize") or 2)
 
-    pretty_left = pformat(left, indent=TABSIZE, width=half_cols).splitlines()
-    pretty_right = pformat(right, indent=TABSIZE, width=half_cols).splitlines()
+    if (
+        config.getoption("--icdiff-multiline-string")
+        and isinstance(left, str)
+        and isinstance(right, str)
+    ):
+        pretty_left = left.splitlines()
+        pretty_right = right.splitlines()
+    else:
+        pretty_left = pformat(left, indent=TABSIZE, width=half_cols).splitlines()
+        pretty_right = pformat(right, indent=TABSIZE, width=half_cols).splitlines()
     diff_cols = COLS - MARGINS
 
     if len(pretty_left) < 3 or len(pretty_right) < 3:

--- a/pytest_icdiff.py
+++ b/pytest_icdiff.py
@@ -56,12 +56,6 @@ def pytest_addoption(parser):
         action="store_true",
         help="pytest-icdiff:  strip any trailing carriage return at the end of an input line",
     )
-    parser.addoption(
-        "--icdiff-multiline-string",
-        default=False,
-        action="store_true",
-        help="pytest-icdiff:  proper differences for multiline strings",
-    )
 
 
 def pytest_assertrepr_compare(config, op, left, right):
@@ -82,11 +76,7 @@ def pytest_assertrepr_compare(config, op, left, right):
     half_cols = COLS / 2 - MARGINS
     TABSIZE = int(config.getoption("--icdiff-tabsize") or 2)
 
-    if (
-        config.getoption("--icdiff-multiline-string")
-        and isinstance(left, str)
-        and isinstance(right, str)
-    ):
+    if isinstance(left, str) and isinstance(right, str):
         pretty_left = left.splitlines()
         pretty_right = right.splitlines()
     else:

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -229,6 +229,19 @@ def test_long_lines_in_comparators_are_wrapped_sensibly_singleline(testdir):
     assert comparison_line.count("hell") < 15
 
 
+def test_mutliline_strings_have_no_escaped_newlines(testdir):
+    testdir.makepyfile(
+        """
+        def test_one():
+            one = "a\nb\nc\nd\ne\nf"
+            two = "a\nb\nc\nd\ne\nf\ng"
+            assert one == two"""
+    )
+    output = testdir.runpytest("-vv", "--color=yes").stdout.str()
+    assert "\\n" not in output
+    assert "\n" in output
+
+
 def test_columns_are_calculated_outside_hook(testdir):
     """
     ok for some reason if you get the TerminalWriter width

--- a/tests/test_pytest_icdiff.py
+++ b/tests/test_pytest_icdiff.py
@@ -231,15 +231,17 @@ def test_long_lines_in_comparators_are_wrapped_sensibly_singleline(testdir):
 
 def test_mutliline_strings_have_no_escaped_newlines(testdir):
     testdir.makepyfile(
-        """
+        r"""
         def test_one():
-            one = "a\nb\nc\nd\ne\nf"
-            two = "a\nb\nc\nd\ne\nf\ng"
+            one = "a\nb\nc\nd"
+            two = "a\nb\nc\ndd"
             assert one == two"""
     )
     output = testdir.runpytest("-vv", "--color=yes").stdout.str()
-    assert "\\n" not in output
-    assert "\n" in output
+    print(repr(output))
+    assert "a" + " " * 36 in output
+    assert "b" + " " * 36 in output
+    assert "c" + " " * 36 in output
 
 
 def test_columns_are_calculated_outside_hook(testdir):


### PR DESCRIPTION
I had the same issue as https://github.com/hjwp/pytest-icdiff/issues/14 where my multiline string difference was not very readable:
<img width="1130" alt="image" src="https://github.com/hjwp/pytest-icdiff/assets/6176998/51c26184-6d1d-41b4-aa75-f2c89e5e5e8a">

I added a command line option `--icdiff-multiline-string`. Running the same test with `pytest --icdiff-multiline-string -vv` now returns a significantly more readable diff:
<img width="1269" alt="image" src="https://github.com/hjwp/pytest-icdiff/assets/6176998/56a26802-c50c-42c2-81c7-89b11a705d39">